### PR TITLE
Use the repository instead of the homepage field in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ['Narrowlink <opensource@narrowlink.com>']
 description = 'Implementation of UdpSocket same as TcpStream'
 edition = '2021'
-homepage = 'https://github.com/narrowlink/udp-stream'
+repository = 'https://github.com/narrowlink/udp-stream'
 license = 'MIT'
 name = 'udp-stream'
 version = '0.0.12'


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.