### PR TITLE
add UdpListener::from_tokio()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,11 +54,12 @@ impl Drop for UdpListener {
 }
 
 impl UdpListener {
+    /// Binds the `UdpListener` to the given local address.
     pub async fn bind(local_addr: SocketAddr) -> io::Result<Self> {
         let udp_socket = UdpSocket::bind(local_addr).await?;
         Self::from_tokio(udp_socket).await
     }
-
+    /// Creates a `UdpListener` from an existing `tokio::net::UdpSocket`.
     pub async fn from_tokio(udp_socket: UdpSocket) -> io::Result<Self> {
         let (tx, rx) = mpsc::channel(CHANNEL_LEN);
         let local_addr = udp_socket.local_addr()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,8 +55,12 @@ impl Drop for UdpListener {
 
 impl UdpListener {
     pub async fn bind(local_addr: SocketAddr) -> io::Result<Self> {
-        let (tx, rx) = mpsc::channel(CHANNEL_LEN);
         let udp_socket = UdpSocket::bind(local_addr).await?;
+        Self::from_tokio(udp_socket).await
+    }
+
+    pub async fn from_tokio(udp_socket: UdpSocket) -> io::Result<Self> {
+        let (tx, rx) = mpsc::channel(CHANNEL_LEN);
         let local_addr = udp_socket.local_addr()?;
 
         let handler = tokio::spawn(async move {


### PR DESCRIPTION
This method allow developer to create the udp socket and config it. One of it's benefit is to solve [the "Connection Reset" error on UDP](https://stackoverflow.com/questions/10332630/connection-reset-on-receiving-packet-in-udp-server) on Windows system.